### PR TITLE
Reject promises with errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 spec/integration/spec.bundle.js
+node_modules/
+*.log

--- a/src/lock.js
+++ b/src/lock.js
@@ -28,8 +28,8 @@ var allPromisesComplete = function (promises) {
   var finalPromise = Hoard.Promise.resolve;
   var allPromise = _.reduce(promises, function (memo, promise) {
     var pass = function () { return promise; };
-    var fail = function () {
-      finalPromise = Hoard.Promise.reject();
+    var fail = function (error) {
+      finalPromise = Hoard.Promise.reject(error);
       return promise;
     };
     return memo.then(pass, fail);

--- a/src/store-helpers.js
+++ b/src/store-helpers.js
@@ -29,7 +29,7 @@ module.exports = {
         if (storedValue !== null) {
           return storedValue;
         } else {
-          return Hoard.Promise.reject();
+          return Hoard.Promise.reject(new Error('Not found'));
         }
       });
   },

--- a/src/store.js
+++ b/src/store.js
@@ -37,13 +37,13 @@ _.extend(Store.prototype, Hoard.Events, {
       _.identity,
       _.bind(function (error) {
         var errorHandler = function () {
-          return Hoard.Promise.reject({
+          return Hoard.Promise.reject(new Error({
             key: key,
             value: item,
             meta: meta,
             error: error,
             options: options
-          });
+          }));
         };
         return this.invalidate(key, options)
           .then(errorHandler, errorHandler);

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -136,12 +136,21 @@ _.extend(Strategy.prototype, Hoard.Events, {
           }, this);
           return Hoard.Promise.all(evictions);
         } else {
-          return Hoard.Promise.reject();
+          return Hoard.Promise.reject(new Error({
+            message: 'Could not clear memory',
+            error: error,
+            value: value
+          }));
         }
       }, this));
     }, this)).then(
       _.bind(this.set, this, key, value, meta, options),
-      function () { return Hoard.Promise.reject(value); }
+      function () {
+        return Hoard.Promise.reject(new Error({
+          value: value,
+          error: error
+        }));
+      }
     );
   },
 


### PR DESCRIPTION
For discussion:

[Bluebird and some other implementations will warn when you reject a promise without an error](https://github.com/petkaantonov/bluebird/blob/master/docs/docs/warning-explanations.md#warning-a-promise-was-rejected-with-a-non-error). This changeset ensures a promise is always rejected with an error object